### PR TITLE
config: AdSense 광고 코드 복원 (ca-pub-9882237042146290)

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -69,4 +69,4 @@ smartTOC = true
   groupByYear = true
 
 [advertisement]
-  # adsense = ""
+  adsense = "ca-pub-9882237042146290"


### PR DESCRIPTION
Jekyll → Hugo 전환 시 누락된 AdSense 설정을 Blowfish 테마 내장 지원으로 복원

https://claude.ai/code/session_01CvzgZvpNNBWuKkgUAuth2x