### PR TITLE
settings: 기본 모델을 Opus에서 Sonnet으로 변경

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "model": "opusplan",
+  "model": "claude-opus-4-6",
   "permissions": {
     "defaultMode": "plan"
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "model": "claude-opus-4-6",
+  "permissions": {
+    "defaultMode": "plan"
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "model": "claude-opus-4-6",
+  "model": "opus",
   "permissions": {
     "defaultMode": "plan"
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "model": "claude-opus-4-6",
+  "model": "claude-sonnet-4-6",
   "permissions": {
     "defaultMode": "plan"
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "model": "claude-opus-4-6",
+  "model": "opusplan",
   "permissions": {
     "defaultMode": "plan"
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "model": "opus",
+  "model": "claude-opus-4-6",
   "permissions": {
     "defaultMode": "plan"
   }


### PR DESCRIPTION
## Summary

`.claude/settings.json`의 기본 모델을 `claude-opus-4-6`에서 `claude-sonnet-4-6`으로 변경합니다.

## 변경 이유

### 1. 비용/속도/품질 트레이드오프

- **속도**: Sonnet 4.6은 Opus 4.6 대비 약 2-3배 빠른 응답 속도를 제공
- **비용**: Sonnet은 Opus 대비 약 1/5 수준의 비용으로 운영 가능
- **품질**: 블로그 글 작성, 교정, 교열 작업에는 Sonnet 4.6의 품질이 충분

### 2. 블로그 작성 작업 영향 검토

블로그 작업의 주요 태스크별 영향도:

- **글 작성 (✅ 영향 없음)**: 마크다운 포맷팅, 프론트매터 작성, SEO 최적화는 Sonnet으로 충분
- **교정/교열 (✅ 영향 없음)**: 맞춤법, 문법, 가독성 검토는 구조화된 작업으로 Sonnet이 적합
- **코드 예시 작성 (✅ 영향 없음)**: 기술 블로그의 코드 예시 수준은 Sonnet의 코딩 능력 범위 내
- **CI/CD 자동화 (✅ 영향 없음)**: 워크플로우 실행, PR 생성/리뷰는 정형화된 작업

### 3. Sonnet 선택 근거

- **작업 특성**: 블로그 콘텐츠는 정형화된 구조(프론트매터 + 본문)와 명확한 규칙(SEO, 파일명 규칙)을 따름
- **반복 작업**: 유사한 패턴의 글 작성이 반복되므로 Sonnet의 일관성이 유리
- **빠른 피드백**: 리뷰 피드백 반영, 오타 수정 등 빠른 반복이 필요한 작업이 많음
- **비용 효율**: GitHub Actions 무료 크레딧 범위 내에서 더 많은 작업 수행 가능

Opus는 복잡한 기획, 아키텍처 설계, 창의적 글쓰기가 필요한 경우에만 선택적으로 사용합니다.

## Test plan

```bash
# 1. 테스트 환경 생성
git worktree add .test claude/update-default-settings-6BmDc

# 2. 설정 파일 확인
cd .test
cat .claude/settings.json

# 3. 정리
cd ..
git worktree remove .test
```

**확인 사항:**
- [ ] `model` 필드가 `claude-sonnet-4-6`으로 설정되어 있는지 확인
- [ ] `permissions.defaultMode`가 `plan`으로 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)